### PR TITLE
Add plot_model_bc() and extract model data on elements (Issue #37 and #32)

### DIFF
--- a/src/pyissm/plot.py
+++ b/src/pyissm/plot.py
@@ -400,7 +400,8 @@ def plot_model_field(md,
     field : np.ndarray
         A 1D array representing the scalar field to plot. Must be defined on vertices or elements. For 3D models, may be defined across all layers.
     layer : int, optional
-        Index of the horizontal layer to extract for 3D models (1-based indexing). Ignored for 2D models. If not provided, the surface layer is used by default for vertex- and element-based 3D fields.
+        Index of the horizontal layer to extract for 3D models (1-based indexing). Ignored for 2D models.
+        If not provided, the surface layer is used by default for vertex- and element-based 3D fields.
     ax : matplotlib.axes.Axes, optional
         An existing matplotlib Axes object to plot on. If `None`, a new figure and axes are created.
     xlabel : str, optional
@@ -457,7 +458,7 @@ def plot_model_field(md,
         # If a 3D model is provided, extract the layer (if provided), or continue to default extraction of surface layer
         if layer is not None:
             # Extract the specified layer
-            field = utils.extract_field_layer(md, field, layer)
+            field, _ = utils.extract_field_layer(md, field, layer)
         else:
             # Default behaviour for 3D model with no layer specified
             if field.shape == md.mesh.numberofvertices:

--- a/src/pyissm/plot.py
+++ b/src/pyissm/plot.py
@@ -521,3 +521,206 @@ def plot_model_field(md,
         return fig, ax
     else:
         return ax
+
+def plot_model_bc(md,
+                  type = 'stressbalance',
+                  ax = None,
+                  scale = 10,
+                  figsize = (6.4, 4.8),
+                  constrained_layout = True,
+                  show_mesh = True,
+                  mesh_args = {},
+                  show_legend = True,
+                  legend_args = {}):
+    """
+    Plot Dirichlet and Neumann boundary conditions from an ISSM model.
+
+    This function visualizes boundary conditions for a specified model
+    component (e.g., `stressbalance`, `masstransport`, `thermal`, etc.) on
+    a 2D or 3D mesh. Dirichlet conditions are plotted as colored markers,
+    and Neumann boundaries (e.g. ice-front) plotted as coloured elements.
+
+    Parameters
+    ----------
+    md : ISSM Model object
+        ISSM Model object containing mesh. Must be compatible with process_mesh()
+    type : str, optional
+        The boundary condition type to plot. Must be one of:
+        'stressbalance', 'masstransport', 'thermal',
+        'balancethickness', 'hydrology', 'debris', or 'levelset'.
+        Default is 'stressbalance'.
+    ax : matplotlib.axes.Axes, optional
+        Existing matplotlib Axes object. If not provided, a new figure and
+        axes are created.
+    scale : float, optional
+        Scaling factor for Dirichlet marker sizes. Default is 10.
+    figsize : tuple of float, optional
+        Size of the figure in inches (width, height). Default is (6.4, 4.8).
+    constrained_layout : bool, optional
+        Whether to use constrained layout for figure spacing. Default is True.
+    show_mesh : bool, optional
+        Whether to display the model mesh beneath boundary markers. Default is True.
+    mesh_args : dict, optional
+        Additional keyword arguments passed to the mesh plotting function.
+        Overrides default {'alpha': 0.5}.
+    show_legend : bool, optional
+        Whether to display a legend showing boundary condition types. Default is True.
+    legend_args : dict, optional
+        Additional keyword arguments passed to `ax.legend()`. Overrides default
+        {'title': 'Boundary condition', 'fontsize': 10, 'loc': 'upper right'}.
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        The matplotlib Figure object (only returned if `ax` is not provided).
+    ax : matplotlib.axes.Axes
+        The matplotlib Axes object containing the plot.
+
+    Notes
+    -----
+    - For 3D models, only surface boundary conditions are plotted.
+    - Neumann (ice-front) elements are included by default as blue elements.
+    - If no constraints are found for a given boundary condition, a message
+      is printed and nothing is plotted for that type.
+
+    Examples
+    --------
+    fig, ax = plot_model_bc(md)
+    fig, ax = plot_model_bc(md, scale = 1)
+    fig, ax = plot_model_bc(md, type='thermal', mesh_args = {'color': 'grey'}, legend_args = {'title': 'Model BCs'})
+
+    See Also
+    --------
+    plot_model_elements : Used internally to visualize Neumann conditions and mesh.
+    """
+
+    ## Set defaults
+    ax_defined = ax is not None
+
+    default_mesh_args = {'alpha': 0.5}
+    default_mesh_args.update(**mesh_args)
+
+    default_legend_args = {'title': 'Boundary condition',
+                           'fontsize': 10,
+                           'loc': 'upper right'}
+    default_legend_args.update(**legend_args)
+
+    ## Process model mesh
+    mesh, mesh_x, mesh_y, mesh_elements, is3d = model.mesh.process_mesh(md)
+
+    ## Get SPC boundaries
+    ## -------------------------------------
+    if type == 'stressbalance':
+        spc_dict = {'spcvx': {'data': md.stressbalance.spcvx,
+                              'label': 'vx Dirichlet',
+                              'col': 'red',
+                              'marker': 'o',
+                              'size': 10 * scale},
+                    'spcvy': {'data': md.stressbalance.spcvy,
+                              'label': 'vy Dirichlet',
+                              'col': 'blue',
+                              'marker': 'o',
+                              'size': 6 * scale},
+                    'spcvz': {'data': md.stressbalance.spcvz,
+                              'label': 'vz Dirichlet',
+                              'col': 'yellow',
+                              'marker': 'o',
+                              'size': 2 * scale}
+                    }
+
+    if type == 'masstransport':
+        spc_dict = {'spcthickness': {'data': md.masstransport.spcthickness,
+                                     'label': 'Thickness Dirichlet',
+                                     'col': 'red',
+                                     'marker': 'o',
+                                     'size': 5 * scale}
+                    }
+
+    if type == 'thermal':
+        spc_dict = {'spctemperature': {'data': md.thermal.spctemperature,
+                                       'label': 'Temperature Dirichlet',
+                                       'col': 'red',
+                                       'marker': 'o',
+                                       'size': 5 * scale}
+                    }
+
+    if type == 'balancethickness':
+        spc_dict = {'spcthickness': {'data': md.balancethickness.spcthickness,
+                                     'label': 'Thickness Dirichlet',
+                                     'col': 'red',
+                                     'marker': 'o',
+                                     'size': 5 * scale}
+                    }
+
+    if type == 'hydrology':
+        spc_dict = {'spcwatercolumn': {'data': md.hydrology.spcwatercolumn,
+                                     'label': 'Water column Dirichlet',
+                                     'col': 'red',
+                                     'marker': 'o',
+                                     'size': 5 * scale}
+                    }
+
+    if type == 'debris':
+        spc_dict = {'spcthickness': {'data': md.debris.spcthickness,
+                                     'label': 'Thickness Dirichlet',
+                                     'col': 'red',
+                                     'marker': 'o',
+                                     'size': 5 * scale}
+                    }
+
+    if type == 'levelset':
+        spc_dict = {'spclevelset': {'data': md.levelset.spclevelset,
+                                    'label': 'Levelset Dirichlet',
+                                    'col': 'red',
+                                    'marker': 'o',
+                                    'size': 5 * scale}
+                    }
+
+    ## Set-up (or retrieve) figure
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize, constrained_layout=constrained_layout)
+    else:
+        fig = ax.get_figure()
+
+    ## Initiate plot with Neumann BCs (ice-front)
+    ax = plot_model_elements(md,
+                             md.mask.ice_levelset,
+                             md.mask.ocean_levelset,
+                             ax = ax,
+                             type = 'ice_front_elements',
+                             show_mesh = show_mesh,
+                             show_legend = False,
+                             mesh_args = default_mesh_args)
+
+    ## Add Dirichlet BCs
+    for key, spc in spc_dict.items():
+        data = spc['data']
+
+        # If the data are all NaN, there are no constraints
+        if np.isnan(data).all():
+            print(f'No constraints found in {key}')
+            pass
+        else:
+            # If model is 3D, extract the BCs on the surface layer
+            if is3d:
+                data = data[md.mesh.vertexonsurface == 1]
+                warnings.warn(f'3D model found. Plotting surface BCs only.')
+
+            # Make plot
+            ax.scatter(mesh_x[~np.isnan(data)],
+                       mesh_y[~np.isnan(data)],
+                       c = spc['col'],
+                       marker = spc['marker'],
+                       s = spc['size'],
+                       label = spc['label'])
+
+    ## Add optional legend (including manual entry for Neumann ice-front)
+    if show_legend:
+        ice_front = matplotlib.patches.Patch(color = 'blue', label ='Neumann (ice-front)')
+        ax.legend(handles=[ice_front] + ax.get_legend_handles_labels()[0], **default_legend_args)
+
+    ## Return
+    if not ax_defined:
+        return fig, ax
+    else:
+        return ax

--- a/src/pyissm/plot.py
+++ b/src/pyissm/plot.py
@@ -341,8 +341,8 @@ def plot_model_elements(md,
     colors = np.ones(np.shape(mesh_elements[element_pos])[0])
     cmap = matplotlib.colors.ListedColormap(color)
 
-    ## Plot elements
-    ax.tripcolor(mesh_x, mesh_y, mesh_elements[element_pos], facecolors=colors, cmap = cmap, edgecolors = 'none')
+    ## Plot elements (shading = 'flat' [default] is required when data are defined on elements)
+    ax.tripcolor(mesh_x, mesh_y, mesh_elements[element_pos], facecolors=colors, cmap = cmap, edgecolors = 'none', shading = 'flat')
 
     ## Add mesh (optional) with specific arguments
     if show_mesh:
@@ -374,6 +374,7 @@ def plot_model_field(md,
                      field,
                      layer = None,
                      ax = None,
+                     shading = 'gouraud',
                      xlabel = 'X (m)',
                      ylabel = 'Y (m)',
                      edgecolors = 'face',
@@ -404,6 +405,10 @@ def plot_model_field(md,
         If not provided, the surface layer is used by default for vertex- and element-based 3D fields.
     ax : matplotlib.axes.Axes, optional
         An existing matplotlib Axes object to plot on. If `None`, a new figure and axes are created.
+    shading : str, optional
+        Type of shading, controlling the visualisation of data. Options: 'flat' or 'gouraud'.
+        Default is 'gouraud' which defines data on points. 'flat' takes the average of three points for each triangle.
+        'flat' is required when data are defined on elements. This is changed automatically if element-based data are provided.
     xlabel : str, optional
         Label for the x-axis. Default is 'X (m)'.
     ylabel : str, optional
@@ -481,6 +486,11 @@ def plot_model_field(md,
         if field.shape[0] not in (md.mesh.numberofvertices, md.mesh.numberofelements):
             raise Exception('plot_model_field: The provided field is an unexpected shape.')
 
+    ## When field is defined on elements, shading = 'flat' is required. Change and warn if 'flat' is not already specified
+    if field.shape == md.mesh.numberofelements2d and shading == 'gouraud':
+        shading = 'flat'
+        warnings.warn("Changing to shading = 'flat' when plotting data defined on elements")
+
     ## If no ax is defined, create new figure (with fig_kwargs, if provided)
     ## otherwise, plot on defined ax
     if ax is None:
@@ -489,7 +499,7 @@ def plot_model_field(md,
         fig = ax.get_figure()
 
     ## Plot field
-    trip = ax.tripcolor(mesh, field, edgecolors = edgecolors, norm = norm, **kwargs)
+    trip = ax.tripcolor(mesh, field, edgecolors = edgecolors, norm = norm, **kwargs, shading = shading)
 
     ## Add optional mesh
     if show_mesh:

--- a/src/pyissm/plot.py
+++ b/src/pyissm/plot.py
@@ -374,7 +374,7 @@ def plot_model_field(md,
                      field,
                      layer = None,
                      ax = None,
-                     shading = 'gouraud',
+                     plot_data_on = 'points',
                      xlabel = 'X (m)',
                      ylabel = 'Y (m)',
                      edgecolors = 'face',
@@ -405,10 +405,10 @@ def plot_model_field(md,
         If not provided, the surface layer is used by default for vertex- and element-based 3D fields.
     ax : matplotlib.axes.Axes, optional
         An existing matplotlib Axes object to plot on. If `None`, a new figure and axes are created.
-    shading : str, optional
-        Type of shading, controlling the visualisation of data. Options: 'flat' or 'gouraud'.
-        Default is 'gouraud' which defines data on points. 'flat' takes the average of three points for each triangle.
-        'flat' is required when data are defined on elements. This is changed automatically if element-based data are provided.
+    plot_data_on: str, optional
+        Should data be plotted on points or elements? Default is 'points'. These options are converted to 'shading' used by plt.tripcolor(), as follows:
+        plot_data_on = 'points': shading = 'gouraud' / plot_data_on = 'elements': shading = 'flat'. When data are defined on elements, plot_data_on = 'elements'
+        is selected automatically internally.
     xlabel : str, optional
         Label for the x-axis. Default is 'X (m)'.
     ylabel : str, optional
@@ -454,6 +454,7 @@ def plot_model_field(md,
     ## Set defaults
     ax_defined = ax is not None
     norm = matplotlib.colors.LogNorm() if log else None
+    shading = 'gouraud' # Consistent with plot_data_on = 'points'
 
     ## Process mesh
     mesh, mesh_x, mesh_y, mesh_elements, is3d = model.mesh.process_mesh(md)
@@ -486,10 +487,12 @@ def plot_model_field(md,
         if field.shape[0] not in (md.mesh.numberofvertices, md.mesh.numberofelements):
             raise Exception('plot_model_field: The provided field is an unexpected shape.')
 
-    ## When field is defined on elements, shading = 'flat' is required. Change and warn if 'flat' is not already specified
-    if field.shape == md.mesh.numberofelements2d and shading == 'gouraud':
+    ## Update shading, if necessary. When field is defined on elements, shading = 'flat' is required.
+    if field.shape == md.mesh.numberofelements2d and plot_data_on == 'points':
         shading = 'flat'
-        warnings.warn("Changing to shading = 'flat' when plotting data defined on elements")
+        warnings.warn("Using plot_data_on = 'elements'. Data are defined on elements")
+    if plot_data_on == 'elements':
+        shading = 'flat'
 
     ## If no ax is defined, create new figure (with fig_kwargs, if provided)
     ## otherwise, plot on defined ax


### PR DESCRIPTION
This PR contains the following:
- Add `plot_model_bc()` to plot model boundary conditions. See Issue #37.
- Update `extract_field_layer()` to extract data defined on mesh elements. See Issue #32.
- Update `plot_model_field()` to include `plot_data_on=...` option that affects how data are visualised. This is converted to the appropriate `shading=...` option for `plt.tripcolor()`. This controls whether data are plotted on the points, or whether the 3 points for each element are averaged and plotted on the elements.

Example usage for updated plotting functions:
`plot_model_bc(md)`
`plot_model_bc(md, type = 'masstransport')`
`plot_model_bc(md, mesh_args = {'color': 'red'}, legend_args = {'title': 'My awesome model BCs'})`

`plot_model_field(md, md.friction.coefficient, plot_data_on = 'elements')`
