### PR TITLE
Updates to plotting func & rename build -> param in model sub-class doc-strings

### DIFF
--- a/src/pyissm/param/amr.py
+++ b/src/pyissm/param/amr.py
@@ -67,7 +67,7 @@ class amr(class_registry.manage_state):
 
     Examples
     -------
-    md.amr = pyissm.build.amr()
+    md.amr = pyissm.param.amr()
     md.amr.hmin = 50
     md.amr.fieldname = 'Thickness'
     """ 

--- a/src/pyissm/param/autodiff.py
+++ b/src/pyissm/param/autodiff.py
@@ -58,7 +58,7 @@ class autodiff(class_registry.manage_state):
 
     Examples
     --------
-    md.autodiff = pyissm.build.autodiff()
+    md.autodiff = pyissm.param.autodiff()
     md.autodiff.isautodiff = 1
     md.autodiff.dependents = ['Vel']
     md.autodiff.independents = ['MaterialsRheologyBbar']

--- a/src/pyissm/param/balancethickness.py
+++ b/src/pyissm/param/balancethickness.py
@@ -42,7 +42,7 @@ class balancethickness(class_registry.manage_state):
 
     Examples
     --------
-    md.balancethickness = pyissm.build.balancethickness()
+    md.balancethickness = pyissm.param.balancethickness()
     md.balancethickness.spcthickness = 100.0
     md.balancethickness.thickening_rate = 0.1
     """

--- a/src/pyissm/param/basalforcings.py
+++ b/src/pyissm/param/basalforcings.py
@@ -40,7 +40,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    md.basalforcings = pyissm.build.basalforcings.default()
+    md.basalforcings = pyissm.param.basalforcings.default()
     md.basalforcings.groundedice_melting_rate = np.zeros((md.mesh.numberofvertices,))
     md.basalforcings.floatingice_melting_rate = np.ones((md.mesh.numberofvertices,)) * 2
     """
@@ -120,7 +120,7 @@ class pico(class_registry.manage_state):
 
     Examples
     --------
-    md.basalforcings = pyissm.build.basalforcings.pico()
+    md.basalforcings = pyissm.param.basalforcings.pico()
     md.basalforcings.num_basins = 3
     md.basalforcings.basin_id = np.array([1, 2, 3])
     md.basalforcings.farocean_temperature = np.array([273.15, 273.2, 273.1])
@@ -208,7 +208,7 @@ class linear(class_registry.manage_state):
 
     Examples
     --------
-    md.basalforcings = pyissm.build.basalforcings.linear()
+    md.basalforcings = pyissm.param.basalforcings.linear()
     md.basalforcings.deepwater_melting_rate = 1.5
     md.basalforcings.deepwater_elevation = -500
     md.basalforcings.upperwater_melting_rate = 0.5
@@ -308,7 +308,7 @@ class lineararma(class_registry.manage_state):
 
     Examples
     --------
-    md.basalforcings = pyissm.build.basalforcings.lineararma()
+    md.basalforcings = pyissm.param.basalforcings.lineararma()
     """
 
     # Initialise with default parameters
@@ -402,7 +402,7 @@ class mismip(class_registry.manage_state):
 
     Examples
     --------
-    md.basalforcings = pyissm.build.basalforcings.mismip()
+    md.basalforcings = pyissm.param.basalforcings.mismip()
     md.basalforcings.groundedice_melting_rate = np.zeros((md.mesh.numberofvertices,))
     md.basalforcings.meltrate_factor = 0.2
     md.basalforcings.threshold_thickness = 75.
@@ -494,7 +494,7 @@ class plume(class_registry.manage_state):
 
     Examples
     --------
-    md.basalforcings = pyissm.build.basalforcings.plume()
+    md.basalforcings = pyissm.param.basalforcings.plume()
     md.basalforcings.groundedice_melting_rate = np.zeros((md.mesh.numberofvertices,))
     md.basalforcings.floatingice_melting_rate = np.ones((md.mesh.numberofvertices,)) * 2
     """
@@ -588,7 +588,7 @@ class spatiallinear(class_registry.manage_state):
 
     Examples
     --------
-    md.basalforcings = pyissm.build.basalforcings.spatiallinear()
+    md.basalforcings = pyissm.param.basalforcings.spatiallinear()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/calving.py
+++ b/src/pyissm/param/calving.py
@@ -34,7 +34,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    md.calving = pyissm.build.calving.default()
+    md.calving = pyissm.param.calving.default()
     md.calving.calvingrate = np.zeros((md.mesh.numberofvertices,))
     """
 
@@ -93,7 +93,7 @@ class crevassedepth(class_registry.manage_state):
 
     Examples
     --------
-    md.calving = pyissm.build.calving.crevassedepth()
+    md.calving = pyissm.param.calving.crevassedepth()
     md.calving.crevasse_opening_stress = 1.0
     md.calving.crevasse_threshold = 0.75
     md.calving.water_height = 10.0
@@ -156,7 +156,7 @@ class dev(class_registry.manage_state):
 
     Examples
     --------
-    md.calving = pyissm.build.calving.dev()
+    md.calving = pyissm.param.calving.dev()
     md.calving.stress_threshold_groundedice = 2e6
     md.calving.stress_threshold_floatingice = 200e3
     """
@@ -214,7 +214,7 @@ class levermann(class_registry.manage_state):
 
     Examples
     --------
-    md.calving = pyissm.build.calving.levermann()
+    md.calving = pyissm.param.calving.levermann()
     """
 
     # Initialise with default parameters
@@ -268,7 +268,7 @@ class minthickness(class_registry.manage_state):
 
     Examples
     --------
-    md.calving = pyissm.build.calving.minthickness()
+    md.calving = pyissm.param.calving.minthickness()
     """
 
     # Initialise with default parameters
@@ -345,7 +345,7 @@ class parameterization(class_registry.manage_state):
 
     Examples
     --------
-    md.calving = pyissm.build.calving.parameterization()
+    md.calving = pyissm.param.calving.parameterization()
     md.calving.min_thickness = 50.
     md.calving.use_param = 1
     md.calving.theta = 2.0
@@ -428,7 +428,7 @@ class vonmises(class_registry.manage_state):
 
     Examples
     --------
-    md.calving = pyissm.build.calving.vonmises()
+    md.calving = pyissm.param.calving.vonmises()
     md.calving.stress_threshold_groundedice = 1e6
     md.calving.stress_threshold_floatingice = 150e3
     md.calving.min_thickness = 50.

--- a/src/pyissm/param/constants.py
+++ b/src/pyissm/param/constants.py
@@ -39,7 +39,7 @@ class constants(class_registry.manage_state):
 
     Examples
     --------
-    md.constants = pyissm.build.constants()
+    md.constants = pyissm.param.constants()
     md.constants.g = 9.81
     md.constants.yts = 365.25 * 24.0 * 3600.0
     """

--- a/src/pyissm/param/damage.py
+++ b/src/pyissm/param/damage.py
@@ -66,7 +66,7 @@ class damage(class_registry.manage_state):
 
     Examples
     --------
-    md.damage = pyissm.build.damage()
+    md.damage = pyissm.param.damage()
     md.damage.isdamage = 1
     """
 

--- a/src/pyissm/param/debris.py
+++ b/src/pyissm/param/debris.py
@@ -52,7 +52,7 @@ class debris(class_registry.manage_state):
 
     Examples
     --------
-    md.debris = pyissm.build.debris()
+    md.debris = pyissm.param.debris()
     md.debris.min_thickness = 0.001
     md.debris.packingfraction = 0.02
     md.debris.stabilization = 2

--- a/src/pyissm/param/debug.py
+++ b/src/pyissm/param/debug.py
@@ -35,7 +35,7 @@ class debug(class_registry.manage_state):
 
     Examples
     --------
-    md.debug = pyissm.build.debug()
+    md.debug = pyissm.param.debug()
     md.debug.valgrind = 1
     md.debug.profiling = 1
     """

--- a/src/pyissm/param/dependent.py
+++ b/src/pyissm/param/dependent.py
@@ -46,7 +46,7 @@ class dependent(class_registry.manage_state):
 
     Examples
     --------
-    md.dependent = pyissm.build.dependent()
+    md.dependent = pyissm.param.dependent()
     md.dependent.name = 'Vel'
     md.dependent.exp = 'velocity_observations.exp'
     """

--- a/src/pyissm/param/dsl.py
+++ b/src/pyissm/param/dsl.py
@@ -38,7 +38,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    md.dsl = pyissm.build.dsl.default()
+    md.dsl = pyissm.param.dsl.default()
     """
 
     # Initialise with default parameters
@@ -101,7 +101,7 @@ class mme(class_registry.manage_state):
 
     Examples
     --------
-    md.dsl = pyissm.build.dsl.mme()
+    md.dsl = pyissm.param.dsl.mme()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/esa.py
+++ b/src/pyissm/param/esa.py
@@ -44,7 +44,7 @@ class esa(class_registry.manage_state):
 
     Examples
     --------
-    md.esa = pyissm.build.esa()
+    md.esa = pyissm.param.esa()
     md.esa.deltathickness = thickness_change
     md.esa.love_h = 0.6
     md.esa.love_l = 0.1

--- a/src/pyissm/param/flowequation.py
+++ b/src/pyissm/param/flowequation.py
@@ -72,7 +72,7 @@ class flowequation(class_registry.manage_state):
 
     Examples
     --------
-    md.flowequation = pyissm.build.flowequation()
+    md.flowequation = pyissm.param.flowequation()
     md.flowequation.isSSA = 1
     md.flowequation.fe_SSA = 'P1bubble'
     md.flowequation.FSNitscheGamma = 1e5

--- a/src/pyissm/param/friction.py
+++ b/src/pyissm/param/friction.py
@@ -46,7 +46,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.default()
+    md.friction = pyissm.param.friction.default()
     """
 
     # Initialise with default parameters
@@ -125,7 +125,7 @@ class coulomb(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.coulomb()
+    md.friction = pyissm.param.friction.coulomb()
     """
 
     # Initialise with default parameters
@@ -204,7 +204,7 @@ class coulomb2(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.coulomb2()
+    md.friction = pyissm.param.friction.coulomb2()
     """
 
     # Initialise with default parameters
@@ -281,7 +281,7 @@ class hydro(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.hydro()
+    md.friction = pyissm.param.friction.hydro()
     """
 
     # Initialise with default parameters
@@ -351,7 +351,7 @@ class josh(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.josh()
+    md.friction = pyissm.param.friction.josh()
     """
 
     # Initialise with default parameters
@@ -424,7 +424,7 @@ class pism(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.pism()
+    md.friction = pyissm.param.friction.pism()
     """
 
     # Initialise with default parameters
@@ -493,7 +493,7 @@ class regcoulomb(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.regcoulomb()
+    md.friction = pyissm.param.friction.regcoulomb()
     """
 
     # Initialise with default parameters
@@ -563,7 +563,7 @@ class regcoulomb2(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.regcoulomb2()
+    md.friction = pyissm.param.friction.regcoulomb2()
     """
 
     # Initialise with default parameters
@@ -639,7 +639,7 @@ class schoof(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.schoof()
+    md.friction = pyissm.param.friction.schoof()
     """
 
     # Initialise with default parameters
@@ -709,7 +709,7 @@ class shakti(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.shakti()
+    md.friction = pyissm.param.friction.shakti()
     """
 
     # Initialise with default parameters
@@ -772,7 +772,7 @@ class waterlayer(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.waterlayer()
+    md.friction = pyissm.param.friction.waterlayer()
     """
 
     # Initialise with default parameters
@@ -790,11 +790,11 @@ class waterlayer(class_registry.manage_state):
     def __repr__(self):
         s = 'Basal shear stress parameters: tau_b = coefficient^2 * Neff ^r * |u_b|^(s - 1) * u_b * 1 / f(T)\n(effective stress Neff = rho_ice * g * thickness + rho_water * g * (bed + water_layer), r = q / p and s = 1 / p)\n'
 
-        s = "{}\n".format(param_utils.fielddisplay(self, 'coefficient', 'frictiontemp coefficient [SI]'))
-        s = "{}\n".format(param_utils.fielddisplay(self, 'f', 'f variable for effective pressure'))
-        s = "{}\n".format(param_utils.fielddisplay(self, 'p', 'p exponent'))
-        s = "{}\n".format(param_utils.fielddisplay(self, 'q', 'q exponent'))
-        s = "{}\n".format(param_utils.fielddisplay(self, 'water_layer', 'water thickness at the base of the ice (m)'))
+        s += '{}\n'.format(param_utils.fielddisplay(self, 'coefficient', 'frictiontemp coefficient [SI]'))
+        s += '{}\n'.format(param_utils.fielddisplay(self, 'f', 'f variable for effective pressure'))
+        s += '{}\n'.format(param_utils.fielddisplay(self, 'p', 'p exponent'))
+        s += '{}\n'.format(param_utils.fielddisplay(self, 'q', 'q exponent'))
+        s += '{}\n'.format(param_utils.fielddisplay(self, 'water_layer', 'water thickness at the base of the ice (m)'))
         return s
 
     # Define class string
@@ -838,7 +838,7 @@ class weertman(class_registry.manage_state):
 
     Examples
     --------
-    md.friction = pyissm.build.friction.weertman()
+    md.friction = pyissm.param.friction.weertman()
     """
 
     # Initialise with default parameters
@@ -854,9 +854,9 @@ class weertman(class_registry.manage_state):
     def __repr__(self):
         s = 'Weertman sliding law parameters: Sigma_b = C^(- 1 / m) * |u_b|^(1 / m - 1) * u_b\n'
 
-        s = "{}\n".format(param_utils.fielddisplay(self, 'C', 'friction coefficient [SI]'))
-        s = "{}\n".format(param_utils.fielddisplay(self, 'm', 'm exponent'))
-        s = "{}\n".format(param_utils.fielddisplay(self, 'linearize', '0: not linearized, 1: interpolated linearly, 2: constant per element (default is 0)'))
+        s += '{}\n'.format(param_utils.fielddisplay(self, 'C', 'friction coefficient [SI]'))
+        s += '{}\n'.format(param_utils.fielddisplay(self, 'm', 'm exponent'))
+        s += '{}\n'.format(param_utils.fielddisplay(self, 'linearize', '0: not linearized, 1: interpolated linearly, 2: constant per element (default is 0)'))
         return s
 
     # Define class string

--- a/src/pyissm/param/frontalforcings.py
+++ b/src/pyissm/param/frontalforcings.py
@@ -36,7 +36,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    md.frontalforcings = pyissm.build.frontalforcings.default()
+    md.frontalforcings = pyissm.param.frontalforcings.default()
     """
 
     # Initialise with default parameters
@@ -98,7 +98,7 @@ class rignot(class_registry.manage_state):
 
     Examples
     --------
-    md.frontalforcings = pyissm.build.frontalforcings.rignot()
+    md.frontalforcings = pyissm.param.frontalforcings.rignot()
     """
 
     # Initialise with default parameters
@@ -210,7 +210,7 @@ class rignotarma(class_registry.manage_state):
 
     Examples
     --------
-    md.frontalforcings = pyissm.build.frontalforcings.rignotarma()
+    md.frontalforcings = pyissm.param.frontalforcings.rignotarma()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/geometry.py
+++ b/src/pyissm/param/geometry.py
@@ -39,7 +39,7 @@ class geometry(class_registry.manage_state):
 
     Examples
     --------
-    md.geometry = pyissm.build.geometry()
+    md.geometry = pyissm.param.geometry()
     md.geometry.surface = surface_elevation
     md.geometry.thickness = ice_thickness
     md.geometry.bed = bed_elevation

--- a/src/pyissm/param/groundingline.py
+++ b/src/pyissm/param/groundingline.py
@@ -39,7 +39,7 @@ class groundingline(class_registry.manage_state):
 
     Examples
     --------
-    md.groundingline = pyissm.build.groundingline()
+    md.groundingline = pyissm.param.groundingline()
     md.groundingline.migration = 'AggressiveMigration'
     md.groundingline.friction_interpolation = 'SubelementFriction2'
     md.groundingline.melt_interpolation = 'SubelementMelt1'

--- a/src/pyissm/param/hydrology.py
+++ b/src/pyissm/param/hydrology.py
@@ -55,7 +55,7 @@ class armapw(class_registry.manage_state):
 
     Examples
     --------
-    md.hydrology = pyissm.build.hydrology.armapw()
+    md.hydrology = pyissm.param.hydrology.armapw()
     """
 
     # Initialise with default parameters
@@ -195,7 +195,7 @@ class dc(class_registry.manage_state):
 
     Examples
     --------
-    md.hydrology = pyissm.build.hydrology.dc()
+    md.hydrology = pyissm.param.hydrology.dc()
     """
 
     # Initialise with default parameters
@@ -368,7 +368,7 @@ class glads(class_registry.manage_state):
 
     Examples
     --------
-    md.hydrology = pyissm.build.hydrology.glads()
+    md.hydrology = pyissm.param.hydrology.glads()
     """
 
     # Initialise with default parameters
@@ -474,7 +474,7 @@ class pism(class_registry.manage_state):
 
     Examples
     --------
-    md.hydrology = pyissm.build.hydrology.pism()
+    md.hydrology = pyissm.param.hydrology.pism()
     """
 
     # Initialise with default parameters
@@ -555,7 +555,7 @@ class shakti(class_registry.manage_state):
 
     Examples
     --------
-    md.hydrology = pyissm.build.hydrology.shakti()
+    md.hydrology = pyissm.param.hydrology.shakti()
     """
 
     # Initialise with default parameters
@@ -638,7 +638,7 @@ class shreve(class_registry.manage_state):
 
     Examples
     --------
-    md.hydrology = pyissm.build.hydrology.shreve()
+    md.hydrology = pyissm.param.hydrology.shreve()
     """
 
     # Initialise with default parameters
@@ -697,7 +697,7 @@ class tws(class_registry.manage_state):
 
     Examples
     --------
-    md.hydrology = pyissm.build.hydrology.tws()
+    md.hydrology = pyissm.param.hydrology.tws()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/independent.py
+++ b/src/pyissm/param/independent.py
@@ -48,7 +48,7 @@ class independent(class_registry.manage_state):
 
     Examples
     --------
-    md.independent = pyissm.build.independent()
+    md.independent = pyissm.param.independent()
     md.independent.name = 'FrictionCoefficient'
     md.independent.type = 'vertex'
     md.independent.min_parameters = 1e-3

--- a/src/pyissm/param/initialization.py
+++ b/src/pyissm/param/initialization.py
@@ -72,7 +72,7 @@ class initialization(class_registry.manage_state):
 
     Examples
     --------
-    md.initialization = pyissm.build.initialization()
+    md.initialization = pyissm.param.initialization()
     md.initialization.vx = vx_initial
     md.initialization.vy = vy_initial
     md.initialization.temperature = temp_initial

--- a/src/pyissm/param/inversion.py
+++ b/src/pyissm/param/inversion.py
@@ -67,7 +67,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    md.inversion = pyissm.build.inversion.default()
+    md.inversion = pyissm.param.inversion.default()
     """
 
     # Initialise with default parameters
@@ -197,7 +197,7 @@ class m1qn3(class_registry.manage_state):
 
     Examples
     --------
-    md.inversion = pyissm.build.inversion.m1qn3()
+    md.inversion = pyissm.param.inversion.m1qn3()
     """
 
     # Initialise with default parameters
@@ -332,7 +332,7 @@ class tao(class_registry.manage_state):
 
     Examples
     --------
-    md.inversion = pyissm.build.inversion.tao()
+    md.inversion = pyissm.param.inversion.tao()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/issmsettings.py
+++ b/src/pyissm/param/issmsettings.py
@@ -45,7 +45,7 @@ class issmsettings(class_registry.manage_state):
 
     Examples
     --------
-    md.settings = pyissm.build.issmsettings()
+    md.settings = pyissm.param.issmsettings()
     md.settings.output_frequency = 5
     md.settings.lowmem = 1
     md.settings.results_on_nodes = ['Vel', 'Thickness']

--- a/src/pyissm/param/levelset.py
+++ b/src/pyissm/param/levelset.py
@@ -42,7 +42,7 @@ class levelset(class_registry.manage_state):
 
     Examples
     --------
-    md.levelset = pyissm.build.levelset()
+    md.levelset = pyissm.param.levelset()
     md.levelset.stabilization = 5
     md.levelset.reinit_frequency = 5
     md.levelset.kill_icebergs = 0

--- a/src/pyissm/param/love.py
+++ b/src/pyissm/param/love.py
@@ -90,7 +90,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    md.love = pyissm.build.love.default()
+    md.love = pyissm.param.love.default()
     """
 
     # Initialise with default parameters
@@ -252,7 +252,7 @@ class fourier(class_registry.manage_state):
 
     Examples
     --------
-    md.love = pyissm.build.love.fourier()
+    md.love = pyissm.param.love.fourier()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/lovenumbers.py
+++ b/src/pyissm/param/lovenumbers.py
@@ -56,7 +56,7 @@ class lovenumbers(class_registry.manage_state):
 
     Examples
     --------
-    md.lovenumbers = pyissm.build.lovenumbers()
+    md.lovenumbers = pyissm.param.lovenumbers()
     md.lovenumbers.h = h_love_numbers
     md.lovenumbers.k = k_love_numbers
     md.lovenumbers.l = l_love_numbers

--- a/src/pyissm/param/mask.py
+++ b/src/pyissm/param/mask.py
@@ -34,7 +34,7 @@ class mask(class_registry.manage_state):
 
     Examples
     --------
-    md.mask = pyissm.build.mask()
+    md.mask = pyissm.param.mask()
     md.mask.ice_levelset = ice_levelset_field
     md.mask.ocean_levelset = ocean_levelset_field
     """

--- a/src/pyissm/param/massfluxatgate.py
+++ b/src/pyissm/param/massfluxatgate.py
@@ -38,7 +38,7 @@ class massfluxatgate(class_registry.manage_state):
 
     Examples
     --------
-    md.massfluxatgate = pyissm.build.massfluxatgate()
+    md.massfluxatgate = pyissm.param.massfluxatgate()
     md.massfluxatgate.name = 'terminus_flux'
     md.massfluxatgate.profilename = 'terminus_profile.shp'
     md.massfluxatgate.definitionstring = 'Outputdefinition1'

--- a/src/pyissm/param/masstransport.py
+++ b/src/pyissm/param/masstransport.py
@@ -46,7 +46,7 @@ class masstransport(class_registry.manage_state):
 
     Examples
     --------
-    md.masstransport = pyissm.build.masstransport()
+    md.masstransport = pyissm.param.masstransport()
     md.masstransport.min_thickness = 10.0
     md.masstransport.stabilization = 2
     md.masstransport.hydrostatic_adjustment = 'Incremental'

--- a/src/pyissm/param/materials.py
+++ b/src/pyissm/param/materials.py
@@ -65,7 +65,7 @@ class ice(class_registry.manage_state):
 
     Examples
     --------
-    md.materials = pyissm.build.materials.ice()
+    md.materials = pyissm.param.materials.ice()
     """
 
     # Initialise with default parameters
@@ -154,7 +154,7 @@ class hydro(class_registry.manage_state):
 
     Examples
     --------
-    md.materials = pyissm.build.materials.hydro()
+    md.materials = pyissm.param.materials.hydro()
     """
 
     # Initialise with default parameters
@@ -241,7 +241,7 @@ class litho(class_registry.manage_state):
 
     Examples
     --------
-    md.materials = pyissm.build.materials.litho()
+    md.materials = pyissm.param.materials.litho()
     """
 
     # Initialise with default parameters
@@ -354,7 +354,7 @@ class damageice(class_registry.manage_state):
 
     Examples
     --------
-    md.materials = pyissm.build.materials.damageice()
+    md.materials = pyissm.param.materials.damageice()
     """
 
     # Initialise with default parameters
@@ -473,7 +473,7 @@ class enhancedice(class_registry.manage_state):
 
     Examples
     --------
-    md.materials = pyissm.build.materials.enhancedice()
+    md.materials = pyissm.param.materials.enhancedice()
     """
 
     # Initialise with default parameters
@@ -594,7 +594,7 @@ class estar(class_registry.manage_state):
 
     Examples
     --------
-    md.materials = pyissm.build.materials.estar()
+    md.materials = pyissm.param.materials.estar()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/mesh.py
+++ b/src/pyissm/param/mesh.py
@@ -69,7 +69,7 @@ class mesh2d(class_registry.manage_state):
 
     Examples
     --------
-    md.mesh = pyissm.build.mesh.mesh2d()
+    md.mesh = pyissm.param.mesh.mesh2d()
     """
 
     # Initialise with default parameters
@@ -201,7 +201,7 @@ class mesh2dvertical(class_registry.manage_state):
 
     Examples
     --------
-    md.mesh = pyissm.build.mesh.mesh2dvertical()
+    md.mesh = pyissm.param.mesh.mesh2dvertical()
     """
 
     # Initialise with default parameters
@@ -349,7 +349,7 @@ class mesh3dprisms(class_registry.manage_state):
 
     Examples
     --------
-    md.mesh = pyissm.build.mesh.mesh3dprisms()
+    md.mesh = pyissm.param.mesh.mesh3dprisms()
     """
 
     # Initialise with default parameters
@@ -504,7 +504,7 @@ class mesh3dsurface(class_registry.manage_state):
 
     Examples
     --------
-    md.mesh = pyissm.build.mesh.mesh3dsurface()
+    md.mesh = pyissm.param.mesh.mesh3dsurface()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/miscellaneous.py
+++ b/src/pyissm/param/miscellaneous.py
@@ -34,7 +34,7 @@ class miscellaneous(class_registry.manage_state):
 
     Examples
     --------
-    md.miscellaneous = pyissm.build.miscellaneous()
+    md.miscellaneous = pyissm.param.miscellaneous()
     md.miscellaneous.notes = 'Model run for Antarctic ice sheet'
     md.miscellaneous.name = 'Antarctica_2024'
     """

--- a/src/pyissm/param/misfit.py
+++ b/src/pyissm/param/misfit.py
@@ -50,7 +50,7 @@ class misfit(class_registry.manage_state):
 
     Examples
     --------
-    md.misfit = pyissm.build.misfit()
+    md.misfit = pyissm.param.misfit()
     md.misfit.name = 'velocity_misfit'
     md.misfit.model_string = 'Vel'
     md.misfit.observation = observed_velocity

--- a/src/pyissm/param/nodalvalue.py
+++ b/src/pyissm/param/nodalvalue.py
@@ -38,7 +38,7 @@ class nodalvalue(class_registry.manage_state):
 
     Examples
     --------
-    md.nodalvalue = pyissm.build.nodalvalue()
+    md.nodalvalue = pyissm.param.nodalvalue()
     md.nodalvalue.name = 'velocity_at_glacier_terminus'
     md.nodalvalue.model_string = 'Vel'
     md.nodalvalue.node = 1245

--- a/src/pyissm/param/offlinesolidearthsolution.py
+++ b/src/pyissm/param/offlinesolidearthsolution.py
@@ -36,7 +36,7 @@ class offlinesolidearthsolution(class_registry.manage_state):
 
     Examples
     --------
-    md.solidearth = pyissm.build.offlinesolidearthsolution()
+    md.solidearth = pyissm.param.offlinesolidearthsolution()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/outputdefinition.py
+++ b/src/pyissm/param/outputdefinition.py
@@ -31,7 +31,7 @@ class outputdefinition(class_registry.manage_state):
 
     Examples
     --------
-    md.outputdefinition = pyissm.build.outputdefinition()
+    md.outputdefinition = pyissm.param.outputdefinition()
     md.outputdefinition.definitions = ['IceVolume', 'IceVolumeAboveFloatation', 'CustomOutput1']
     """
 

--- a/src/pyissm/param/private.py
+++ b/src/pyissm/param/private.py
@@ -38,7 +38,7 @@ class private(class_registry.manage_state):
 
     Examples
     --------
-    md.private = pyissm.build.private()
+    md.private = pyissm.param.private()
     md.private.runtimename = 'experiment_001'
     md.private.solution = 'StressBalance'
     """

--- a/src/pyissm/param/radaroverlay.py
+++ b/src/pyissm/param/radaroverlay.py
@@ -36,7 +36,7 @@ class radaroverlay(class_registry.manage_state):
 
     Examples
     --------
-    md.radaroverlay = pyissm.build.radaroverlay()
+    md.radaroverlay = pyissm.param.radaroverlay()
     md.radaroverlay.pwr = radar_power_matrix
     md.radaroverlay.x = x_coordinates
     md.radaroverlay.y = y_coordinates

--- a/src/pyissm/param/regionaloutput.py
+++ b/src/pyissm/param/regionaloutput.py
@@ -40,7 +40,7 @@ class regionaloutput(class_registry.manage_state):
 
     Examples
     --------
-    md.regionaloutput = pyissm.build.regionaloutput()
+    md.regionaloutput = pyissm.param.regionaloutput()
     md.regionaloutput.name = 'west_antarctica_volume'
     md.regionaloutput.outputnamestring = 'IceVolume'
     md.regionaloutput.mask = west_antarctica_mask

--- a/src/pyissm/param/results.py
+++ b/src/pyissm/param/results.py
@@ -35,7 +35,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    results = pyissm.build.results.default()
+    results = pyissm.param.results.default()
     """
 
     # Initialise with default parameters
@@ -95,7 +95,7 @@ class resultsdakota(class_registry.manage_state):
 
     Examples
     --------
-    results = pyissm.build.results.resultsdakota()
+    results = pyissm.param.results.resultsdakota()
     """
 
     # Initialise with default parameters
@@ -157,7 +157,7 @@ class solution(class_registry.manage_state):
 
     Examples
     --------
-    results = pyissm.build.results.solution()
+    results = pyissm.param.results.solution()
     """
 
     # Initialise with default parameters
@@ -228,7 +228,7 @@ class solutionstep(class_registry.manage_state):
 
     Examples
     --------
-    step = pyissm.build.results.solutionstep()
+    step = pyissm.param.results.solutionstep()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/rifts.py
+++ b/src/pyissm/param/rifts.py
@@ -33,7 +33,7 @@ class rifts(class_registry.manage_state):
 
     Examples
     --------
-    md.rifts = pyissm.build.rifts()
+    md.rifts = pyissm.param.rifts()
     md.rifts.riftstruct = rift_structure_data
     md.rifts.riftproperties = rift_properties_data
     """

--- a/src/pyissm/param/rotational.py
+++ b/src/pyissm/param/rotational.py
@@ -34,7 +34,7 @@ class rotational(class_registry.manage_state):
 
     Examples
     --------
-    md.rotational = pyissm.build.rotational()
+    md.rotational = pyissm.param.rotational()
     """
 
     # Initialise with default parameters

--- a/src/pyissm/param/sampling.py
+++ b/src/pyissm/param/sampling.py
@@ -46,7 +46,7 @@ class sampling(class_registry.manage_state):
 
     Examples
     --------
-    md.sampling = pyissm.build.sampling()
+    md.sampling = pyissm.param.sampling()
     md.sampling.kappa = 0.1
     md.sampling.alpha = 2.0
     md.sampling.phi = 0.9

--- a/src/pyissm/param/smb.py
+++ b/src/pyissm/param/smb.py
@@ -40,7 +40,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.default()
+    md.smb = pyissm.param.smb.default()
     """
 
     # Initialise with default parameters
@@ -141,7 +141,7 @@ class arma(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.arma()
+    md.smb = pyissm.param.smb.arma()
     """
 
     # Initialise with default parameters
@@ -248,7 +248,7 @@ class components(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.components()
+    md.smb = pyissm.param.smb.components()
     md.smb.accumulation = accumulation_data
     md.smb.runoff = runoff_data
     md.smb.evaporation = evaporation_data
@@ -368,7 +368,7 @@ class d18opdd(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.d18opdd()
+    md.smb = pyissm.param.smb.d18opdd()
     md.smb.delta18o = delta18o_data
     md.smb.temperatures_presentday = temp_data
     """
@@ -490,7 +490,7 @@ class gradients(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.gradients()
+    md.smb = pyissm.param.smb.gradients()
     md.smb.href = reference_elevation
     md.smb.smbref = reference_smb
     md.smb.b_pos = positive_gradient
@@ -589,7 +589,7 @@ class gradientscomponents(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.gradientscomponents()
+    md.smb = pyissm.param.smb.gradientscomponents()
     md.smb.accuref = reference_accumulation
     md.smb.runoffref = reference_runoff
     """
@@ -688,7 +688,7 @@ class gradientsela(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.gradientsela()
+    md.smb = pyissm.param.smb.gradientsela()
     md.smb.ela = equilibrium_line_altitude
     md.smb.b_pos = positive_gradient  # Above ELA
     md.smb.b_neg = negative_gradient  # Below ELA
@@ -770,7 +770,7 @@ class henning(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.henning()
+    md.smb = pyissm.param.smb.henning()
     md.smb.smbref = reference_smb_data
     """
 
@@ -856,7 +856,7 @@ class meltcomponents(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.meltcomponents()
+    md.smb = pyissm.param.smb.meltcomponents()
     md.smb.accumulation = accumulation_data
     md.smb.melt = melt_data
     md.smb.refreeze = refreeze_data
@@ -983,7 +983,7 @@ class pdd(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.pdd()
+    md.smb = pyissm.param.smb.pdd()
     md.smb.monthlytemperatures = temperature_data
     md.smb.precipitation = precipitation_data
     """
@@ -1129,7 +1129,7 @@ class pddSicopolis(class_registry.manage_state):
 
     Examples
     --------
-    md.smb = pyissm.build.smb.pddSicopolis()
+    md.smb = pyissm.param.smb.pddSicopolis()
     md.smb.monthlytemperatures = temperature_data
     md.smb.precipitation = precipitation_data
     md.smb.temperature_anomaly = temp_anomaly

--- a/src/pyissm/param/solidearth.py
+++ b/src/pyissm/param/solidearth.py
@@ -70,7 +70,7 @@ class earth(class_registry.manage_state):
 
     Examples
     --------
-    md.solidearth = pyissm.build.solidearth.earth()
+    md.solidearth = pyissm.param.solidearth.earth()
     md.solidearth.settings.elastic = 1
     md.solidearth.settings.viscous = 1
     """
@@ -178,7 +178,7 @@ class europa(class_registry.manage_state):
 
     Examples
     --------
-    md.solidearth = pyissm.build.solidearth.europa()
+    md.solidearth = pyissm.param.solidearth.europa()
     md.solidearth.settings.elastic = 1
     md.solidearth.lovenumbers = custom_europa_lovenumbers
     """
@@ -300,7 +300,7 @@ class settings(class_registry.manage_state):
 
     Examples
     --------
-    md.solidearth.settings = pyissm.build.solidearth.settings()
+    md.solidearth.settings = pyissm.param.solidearth.settings()
     md.solidearth.settings.elastic = 1
     md.solidearth.settings.viscous = 1
     md.solidearth.settings.grdmodel = 1

--- a/src/pyissm/param/steadystate.py
+++ b/src/pyissm/param/steadystate.py
@@ -35,7 +35,7 @@ class steadystate(class_registry.manage_state):
 
     Examples
     --------
-    md.steadystate = pyissm.build.steadystate()
+    md.steadystate = pyissm.param.steadystate()
     md.steadystate.reltol = 0.001
     md.steadystate.maxiter = 200
     md.steadystate.requested_outputs = ['IceVolume', 'IceVolumeAboveFloatation']

--- a/src/pyissm/param/stochasticforcing.py
+++ b/src/pyissm/param/stochasticforcing.py
@@ -46,7 +46,7 @@ class stochasticforcing(class_registry.manage_state):
 
     Examples
     --------
-    md.stochasticforcing = pyissm.build.stochasticforcing()
+    md.stochasticforcing = pyissm.param.stochasticforcing()
     md.stochasticforcing.isstochasticforcing = 1
     md.stochasticforcing.fields = ['SMBforcing']
     md.stochasticforcing.defaultdimension = 1

--- a/src/pyissm/param/stressbalance.py
+++ b/src/pyissm/param/stressbalance.py
@@ -74,7 +74,7 @@ class stressbalance(class_registry.manage_state):
 
     Examples
     --------
-    md.stressbalance = pyissm.build.stressbalance()
+    md.stressbalance = pyissm.param.stressbalance()
     md.stressbalance.restol = 1e-5
     md.stressbalance.isnewton = 1
     md.stressbalance.maxiter = 200

--- a/src/pyissm/param/surfaceload.py
+++ b/src/pyissm/param/surfaceload.py
@@ -36,7 +36,7 @@ class surfaceload(class_registry.manage_state):
 
     Examples
     --------
-    md.surfaceload = pyissm.build.surfaceload()
+    md.surfaceload = pyissm.param.surfaceload()
     md.surfaceload.icethicknesschange = ice_thickness_change
     md.surfaceload.waterheightchange = water_height_change
     md.surfaceload.other = sediment_load

--- a/src/pyissm/param/thermal.py
+++ b/src/pyissm/param/thermal.py
@@ -56,7 +56,7 @@ class thermal(class_registry.manage_state):
 
     Examples
     --------
-    md.thermal = pyissm.build.thermal()
+    md.thermal = pyissm.param.thermal()
     md.thermal.isenthalpy = 1
     md.thermal.stabilization = 2
     md.thermal.maxiter = 200

--- a/src/pyissm/param/timestepping.py
+++ b/src/pyissm/param/timestepping.py
@@ -58,7 +58,7 @@ class default(class_registry.manage_state):
 
     Examples
     --------
-    md.timestepping = pyissm.build.timestepping.default()
+    md.timestepping = pyissm.param.timestepping.default()
     md.timestepping.start_time = 0
     md.timestepping.final_time = 100
     md.timestepping.time_step = 1.0
@@ -163,7 +163,7 @@ class adaptive(class_registry.manage_state):
 
     Examples
     --------
-    md.timestepping = pyissm.build.timestepping.adaptive()
+    md.timestepping = pyissm.param.timestepping.adaptive()
     md.timestepping.time_step_min = 0.001
     md.timestepping.time_step_max = 5.0
     md.timestepping.cfl_coefficient = 0.8

--- a/src/pyissm/param/transient.py
+++ b/src/pyissm/param/transient.py
@@ -65,7 +65,7 @@ class transient(class_registry.manage_state):
 
     Examples
     --------
-    md.transient = pyissm.build.transient()
+    md.transient = pyissm.param.transient()
     md.transient.isage = 1
     md.transient.isgroundingline = 1
     md.transient.requested_outputs = ['IceVolume', 'IceVolumeAboveFloatation']

--- a/src/pyissm/plot.py
+++ b/src/pyissm/plot.py
@@ -488,7 +488,7 @@ def plot_model_field(md,
             raise Exception('plot_model_field: The provided field is an unexpected shape.')
 
     ## Update shading, if necessary. When field is defined on elements, shading = 'flat' is required.
-    if field.shape == md.mesh.numberofelements2d and plot_data_on == 'points':
+    if (is3d and field.shape == md.mesh.numberofelements2d and plot_data_on == 'points') or (not is3d and field.shape == md.mesh.numberofelements and plot_data_on == 'points'):
         shading = 'flat'
         warnings.warn("Using plot_data_on = 'elements'. Data are defined on elements")
     if plot_data_on == 'elements':

--- a/src/pyissm/plot.py
+++ b/src/pyissm/plot.py
@@ -485,9 +485,16 @@ def plot_model_field(md,
         # If layer is defined, raise warning to explicitly state that it isn't used
         if layer is not None:
             warnings.warn('plot_model_field: 2D model found. Layer definition is ignored.')
+        
         # If a 2D model is provided, the field should be defined on vertices or elements.
         if field.shape[0] not in (md.mesh.numberofvertices, md.mesh.numberofelements):
-            raise Exception('plot_model_field: The provided field is an unexpected shape.')
+            
+            # If the field has one extra row, it is a timestep. Remove this row for plotting.
+            if (field.shape[0] == md.mesh.numberofvertices + 1) or (field.shape[0] == md.mesh.numberofelements + 1):
+                warnings.warn(f'plot_model_field: Ignoring the timestep value {field[-1]}.')
+                field = field[:-1]
+            else:
+                raise Exception('plot_model_field: The provided field is an unexpected shape.')
 
     ## Update shading, if necessary. When field is defined on elements, shading = 'flat' is required.
     if (is3d and field.shape == md.mesh.numberofelements2d and plot_data_on == 'points') or (not is3d and field.shape == md.mesh.numberofelements and plot_data_on == 'points'):

--- a/src/pyissm/plot.py
+++ b/src/pyissm/plot.py
@@ -73,7 +73,8 @@ def plot_mesh2d(mesh,
     ## Define default node argus and update node_args with passed arguments
     default_node_args = {'marker': '.',
                          'color': 'k',
-                         's': 5}
+                         's': 5,
+                         'zorder': 3}
     default_node_args.update(**node_args)
 
 
@@ -88,6 +89,7 @@ def plot_mesh2d(mesh,
     ax.triplot(mesh,
                color = color,
                linewidth = linewidth,
+               zorder = 2,
                **kwargs)
 
     ## Add optional nodes
@@ -467,15 +469,15 @@ def plot_model_field(md,
             field, _ = utils.extract_field_layer(md, field, layer)
         else:
             # Default behaviour for 3D model with no layer specified
-            if field.shape == md.mesh.numberofvertices:
+            if field.shape[0] == md.mesh.numberofvertices:
                 warnings.warn('plot_model_field: 3D model found with no layer specified. Plotting surface vertices layer only.')
                 field = field[md.mesh.vertexonsurface == 1]
-            elif field.shape == md.mesh.numberofelements:
+            elif field.shape[0] == md.mesh.numberofelements:
                 warnings.warn('plot_model_field: 3D model found with no layer specified. Plotting surface elements layer only.')
                 field = field[np.isnan(md.mesh.upperelements) == 1]
-            elif field.shape == md.mesh.numberofelements2d:
+            elif field.shape[0] == md.mesh.numberofelements2d:
                 pass # Field is defined on 2D mesh elements. Already 2D compatible. Continue
-            elif field.shape == md.mesh.numberofvertices2d:
+            elif field.shape[0] == md.mesh.numberofvertices2d:
                 pass # Field is defined on 2D mesh vertices. Already 2D compatible. Continue
             else:
                 raise Exception('plot_model_field: The provided field is an unexpected shape.')

--- a/src/pyissm/plot.py
+++ b/src/pyissm/plot.py
@@ -724,3 +724,132 @@ def plot_model_bc(md,
         return fig, ax
     else:
         return ax
+    
+def plot_model_ts(md,
+                  data_list = None,
+                  variable_list = None,
+                  unit_list = None,
+                  time = (0, np.inf),
+                  figsize = (6.4, 4.8),
+                  fontsize = 8,
+                  color = 'black',
+                  show_grid = True,
+                  constrained_layout = True,
+                  sharex = True,
+                  **kwargs):
+    """
+    Plot time series data from an ISSM model's TransientSolution.
+
+    Automatically extracts 1D time series arrays from `md.results.TransientSolution` if `data_list` is not provided.
+    Plots each variable as a separate subplot, sharing the x-axis (time).
+    
+    Parameters
+    ----------
+    md : object
+        ISSM model object containing results with a `TransientSolution` attribute.
+    data_list : list of np.ndarray, optional
+        List of 1D numpy arrays to plot. If None, all 1D arrays in `md.results.TransientSolution` (except 'time' and 'step') are used.
+    variable_list : list of str, optional
+        List of variable names corresponding to `data_list`. If None, names are auto-generated or extracted from `TransientSolution`.
+    unit_list : list of str, optional
+        List of units for each variable. If None, defaults to 'Units unspecified' or 'ISSM Units'.
+    time : tuple of float, optional
+        Time range (start, end) to plot. Defaults to (0, np.inf).
+    figsize : tuple of int, optional
+        Figure size in inches. Defaults to (6.4, 4.8).
+    fontsize : int, optional
+        Font size for labels and titles. Defaults to 8.
+    color : str, optional
+        Line color for plots. Defaults to 'black'.
+    show_grid : bool, optional
+        Whether to show grid lines on plots. Defaults to True.
+    constrained_layout : bool, optional
+        Whether to use matplotlib's constrained layout. Defaults to True.
+    sharex : bool, optional
+        Whether subplots share the x-axis. Defaults to True.
+    
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        The matplotlib figure object containing the plots.
+    axs : np.ndarray of matplotlib.axes.Axes
+        Array of axes objects for each subplot.
+    
+    Raises
+    ------
+    ValueError
+        If no time array is found, no 1D time series are available, input lists are mismatched, or data arrays are not 1D.
+
+    Examples
+    --------
+    >>> fig, axs = plot_model_ts(md)
+    >>> fig, axs = plot_model_ts(md, data_list=[arr1, arr2], variable_list=['Var1', 'Var2'], unit_list=['m', 'kg'])
+    """
+
+    # Check if md has the required attributes
+    if hasattr(md, 'results') is False or not hasattr(md.results, 'TransientSolution'):
+        raise ValueError("The provided model does not have a 'results.TransientSolution' attribute.")
+
+    # Extract model time from the TransientSolution
+    model_time = getattr(md.results.TransientSolution, 'time', None)
+    if model_time is None:
+        raise ValueError("No 'time' array found in md.results.TransientSolution.")
+
+    # Auto-extract 1D arrays if no data_list provided
+    if data_list is None:
+        variables = {}
+        for k, v in vars(md.results.TransientSolution).items():
+            # If the variable is a 1D numpy array and not 'time' or 'step' variables, add it to variables dictionary
+            if isinstance(v, np.ndarray) and v.ndim == 1 and k not in ('step', 'time'):
+                variables[k] = v
+        
+        # If no 1D time series found, raise an error
+        if not variables:
+            raise ValueError("No 1D time series found in md.results.TransientSolution.")
+
+        # Construct data_list, variable_list, and unit_list from the variables dictionary. Use 'ISSM units'.    
+        data_list = list(variables.values())
+        variable_list = list(variables.keys())
+        unit_list = ['ISSM Units'] * len(data_list)
+
+    # Check that data_list is not empty
+    n_vars = len(data_list)
+    if n_vars == 0:
+        raise ValueError("data_list must contain at least one 1D numpy array.")
+
+    # Fill missing variable names/units
+    if variable_list is None:
+        variable_list = [f'Variable {i + 1}' for i in range(n_vars)]
+        
+    if unit_list is None:
+        unit_list = ['Units unspecified'] * n_vars
+
+    # Validate input lengths
+    if not (len(data_list) == len(variable_list) == len(unit_list)):
+        raise ValueError("data_list, variable_list, and unit_list must all be the same length.")
+
+    # Check that all data arrays are 1D
+    if not all(arr.ndim == 1 for arr in data_list):
+        raise ValueError("All data in data_list must be 1D numpy arrays.")
+
+    # Filter time range
+    time_idx = np.where((model_time >= time[0]) & (model_time <= time[1]))[0]
+    model_time = model_time[time_idx]
+
+    # Create subplots & ensure axs is iterable even if n_vars == 1
+    fig, axs = plt.subplots(n_vars, 1, figsize=figsize, constrained_layout=constrained_layout, sharex=sharex)
+    axs = np.atleast_1d(axs)
+
+    # Plot each variable iteratively
+    for data, variable, unit, ax in zip(data_list, variable_list, unit_list, axs):
+        ax.plot(model_time, data[time_idx], color = color, **kwargs)
+        ax.set_title(variable, fontsize = fontsize)
+        ax.set_ylabel(f'{variable}\n({unit})', fontsize = fontsize)
+        ax.tick_params(axis = 'both', labelsize = fontsize)
+        if show_grid:
+            ax.grid(alpha = 0.4)
+
+    # Add a common x-label for the last subplot
+    axs[-1].set_xlabel('Year', fontsize = fontsize)
+
+    return fig, axs

--- a/src/pyissm/utils.py
+++ b/src/pyissm/utils.py
@@ -249,7 +249,7 @@ def extract_field_layer(md,
         raise ValueError('extract_field_layer: model mesh is not correctly dimensioned')
 
     ## Extract data defined on elements
-    if field.shape == md.mesh.numberofelements:
+    if field.shape[0] == md.mesh.numberofelements:
 
         # The number of element layers is (md.mesh.numberoflayers - 1). Check that the defined layer can be extracted.
         if not (1 <= layer <= md.mesh.numberoflayers - 1):
@@ -264,7 +264,7 @@ def extract_field_layer(md,
         select_layer = field[select_indices]
 
     ## Extract data defined on vertices
-    if field.shape == md.mesh.numberofvertices:
+    if field.shape[0] == md.mesh.numberofvertices:
         # Identify vertex positions for requested layer
         start_pos = md.mesh.numberofvertices2d * (layer - 1)
         end_pos = md.mesh.numberofvertices2d * layer


### PR DESCRIPTION
This PR contains various minor updates to plotting functions, as follows:
- Fix field shape bug for 3D models.
- Add `plot_model_ts()` to visualise 1D model results timeseries.
- Force plotting order in `plot_mesh2d()` to ensure nodes are plotted on top of mesh.
- Add support for plotting 2D input fields that have a time-dimension.

Additional updates:
- Rename `build` -> `param` in examples in model sub-class doc-strings.
- Fix some repr strings that were not displaying correctly.
- Add support for the optional `variable_map` to be passed as a `pd.Dataframe()` in `export_gridded_model()`.