### PR TITLE
Update model IO and PICO consistency checks

### DIFF
--- a/src/pyissm/model/classes/basalforcings.py
+++ b/src/pyissm/model/classes/basalforcings.py
@@ -307,8 +307,8 @@ class pico(class_registry.manage_state):
             class_utils._check_field(md, fieldname = "basalforcings.overturning_coeff", size = (md.mesh.numberofvertices, ), gt = 0, allow_nan = False, allow_inf = False)
 
         class_utils._check_field(md, fieldname = "basalforcings.gamma_T", scalar = True, gt = 0, allow_nan = False, allow_inf = False)
-        class_utils._check_field(md, fieldname = "basalforcings.farocean_temperature", size = (md.basalforcings.num_basins + 1, None), allow_nan = False, allow_inf = False)
-        class_utils._check_field(md, fieldname = "basalforcings.farocean_salinity", size = (md.basalforcings.num_basins + 1, None), gt = 0, allow_nan = False, allow_inf = False)
+        class_utils._check_field(md, fieldname = "basalforcings.farocean_temperature", size = (md.basalforcings.num_basins + 1, ), allow_nan = False, allow_inf = False)
+        class_utils._check_field(md, fieldname = "basalforcings.farocean_salinity", size = (md.basalforcings.num_basins + 1, ), gt = 0, allow_nan = False, allow_inf = False)
         class_utils._check_field(md, fieldname = "basalforcings.isplume", scalar = True, values = [0, 1])
         class_utils._check_field(md, fieldname = "basalforcings.geothermalflux", timeseries = True, ge = 0, allow_nan = False, allow_inf = False)
         class_utils._check_field(md, fieldname = "basalforcings.groundedice_melting_rate", timeseries = True, allow_nan = False, allow_inf = False)

--- a/src/pyissm/model/io.py
+++ b/src/pyissm/model/io.py
@@ -86,8 +86,8 @@ def load_model(path):
                 continue
             val = group.getncattr(attr)
             
-            ## Convert "__EMPTY_LIST" back to an empty list
-            if isinstance(val, str) and val == "__EMPTY_LIST__":
+            ## Convert "__EMPTY_LIST" (modern pyISSM handling) or "emptycell"/"emptystruct" (legacy MATLAB handling) back to an empty list
+            if isinstance(val, str) and val in ("__EMPTY_LIST__", "emptycell", "emptystruct"):
                 val = []
 
             state[attr] = val
@@ -167,6 +167,7 @@ def load_model(path):
         - Floating-point NaN values are normalized to ``np.nan`` for consistency.
         - Dictionaries, lists, and tuples are processed recursively.
         - NumPy arrays are preserved, with floating-point NaNs normalized in-place.
+        - String values "True" and "False" are converted to integer 1 and 0, respectively.
 
         Parameters
         ----------
@@ -210,6 +211,14 @@ def load_model(path):
         elif isinstance(obj, np.generic):
             return obj.item()
         
+        elif isinstance(obj, str):
+            if obj == "True":
+                return 1
+            elif obj == "False":
+                return 0
+            else:
+                return obj
+            
         else:
             return obj
         


### PR DESCRIPTION
This PR fixes minor bugs/omissions in the PICO field consistency checks & includes handling for special case fields included in legacy MATLAB models converted to NetCDF using the old `export_netcdf.m` function.