### PR TITLE
2026.05.08 -- pyISSM update 

### DIFF
--- a/.github/workflows/benchmark-main-vs-pr.yml
+++ b/.github/workflows/benchmark-main-vs-pr.yml
@@ -84,7 +84,6 @@ jobs:
         run: |
           source "$ISSM_DIR/etc/environment.sh"
           cd "$ISSM_DIR/externalpackages/triangle" && ./install-linux.sh
-          cd "$ISSM_DIR/externalpackages/m1qn3"    && ./install-linux.sh
           cd "$ISSM_DIR/externalpackages/petsc"    && ./install-3.22-linux.sh
           cd "$ISSM_DIR/externalpackages/semic"    && ./install.sh
 

--- a/.github/workflows/build-issm-ad.yml
+++ b/.github/workflows/build-issm-ad.yml
@@ -62,7 +62,6 @@ jobs:
         run: |
           source $ISSM_DIR/etc/environment.sh
           cd $ISSM_DIR/externalpackages/triangle   && ./install-linux.sh
-          cd $ISSM_DIR/externalpackages/m1qn3      && ./install-linux.sh
           cd $ISSM_DIR/externalpackages/petsc      && ./install-3.22-linux.sh
           cd $ISSM_DIR/externalpackages/gsl        && ./install.sh
           cd $ISSM_DIR/externalpackages/codipack   && ./install.sh

--- a/.github/workflows/build-issm-ad.yml
+++ b/.github/workflows/build-issm-ad.yml
@@ -66,7 +66,7 @@ jobs:
           cd $ISSM_DIR/externalpackages/gsl        && ./install.sh
           cd $ISSM_DIR/externalpackages/codipack   && ./install.sh
           cd $ISSM_DIR/externalpackages/medipack   && ./install.sh
-      # If corredponding issm cache doesn't exist, build ISSM
+      # If corresponding issm cache doesn't exist, build ISSM
       - name: Build ISSM AD
         if: ${{ steps.cache-issm-ad-build.outputs.cache-hit != 'true' }}
         working-directory: issm

--- a/.github/workflows/build-issm.yml
+++ b/.github/workflows/build-issm.yml
@@ -62,7 +62,6 @@ jobs:
         run: |
           source $ISSM_DIR/etc/environment.sh
           cd $ISSM_DIR/externalpackages/triangle && ./install-linux.sh
-          cd $ISSM_DIR/externalpackages/m1qn3    && ./install-linux.sh
           cd $ISSM_DIR/externalpackages/petsc    && ./install-3.22-linux.sh
           cd $ISSM_DIR/externalpackages/semic    && ./install.sh
       # If corredponding issm cache doesn't exist, build ISSM

--- a/src/pyissm/model/classes/inversion.py
+++ b/src/pyissm/model/classes/inversion.py
@@ -970,19 +970,6 @@ class adm1qn3(class_registry.manage_state):
         if not self.iscontrol:
             return md
 
-        # Check M1QN3 availability when possible
-        if tools.wrappers.check_wrappers_installed():
-            if not tools.wrappers.IssmConfig("_HAVE_M1QN3_")[0]:
-                md = md.check_message(
-                    "M1QN3 has not been installed. ISSM must be reconfigured "
-                    "and recompiled with M1QN3."
-                )
-        else:
-            warnings.warn(
-                "inversion.adm1qn3.check_consistency: Python wrappers not installed; "
-                "skipping M1QN3 availability check."
-            )
-
         class_utils._check_field(md, fieldname = "inversion.iscontrol", values = [0, 1])
         class_utils._check_field(md, fieldname = "inversion.maxsteps", scalar = True, ge = 0)
         class_utils._check_field(md, fieldname = "inversion.maxiter", scalar = True, ge = 0)

--- a/src/pyissm/model/classes/smb.py
+++ b/src/pyissm/model/classes/smb.py
@@ -1368,6 +1368,8 @@ class gemb(class_registry.manage_state):
         self.isconstrainsurfaceT = 0
         self.isdeltaLWup = 0
         self.ismappedforcing = 0
+        self.ismappingusingneighbors = 0
+        self.ismappingneighborxy = 0
         self.isprecipforcingremapped = 1
         self.iscompressedforcing = 0
         self.Ta = np.nan
@@ -1387,7 +1389,12 @@ class gemb(class_registry.manage_state):
         self.teValue =  np.ones((mesh.numberofelements,))
         self.dulwrfValue = np.zeros((mesh.numberofelements,))
         self.mappedforcingpoint = np.nan
+        self.mappedforcingneighbors = np.nan
         self.mappedforcingelevation = np.nan
+        self.lat_mappedforcing = np.nan
+        self.lon_mappedforcing = np.nan
+        self.x_mappedforcing = np.nan
+        self.y_mappedforcing = np.nan
         self.mappedforcingprecipscaling = 1.0 * np.ones((mesh.numberofelements,))
         self.lapseTaValue = -0.006
         self.lapsedlwrfValue = -0.032
@@ -1427,6 +1434,7 @@ class gemb(class_registry.manage_state):
         self.K = 7
         self.adThresh = 1023
         self.teThresh = 10
+        self.teDefault = 1
         self.InitDensityScaling = 1.0
         self.ThermoDeltaTScaling = 1 / 11.0
         self.steps_per_step = 1
@@ -1450,6 +1458,8 @@ class gemb(class_registry.manage_state):
         s += '{}\n'.format(class_utils._field_display(self, 'isconstrainsurfaceT', 'constrain surface temperatures to air temperature, turn off EC and surface flux contribution to surface temperature change (default false)'))
         s += '{}\n'.format(class_utils._field_display(self, 'isdeltaLWup', 'set to true to invoke a bias in the long wave upward spatially, specified by dulwrfValue (default false)'))
         s += '{}\n'.format(class_utils._field_display(self,'ismappedforcing','set to true if forcing grid does not match model mesh, mapping specified by mappedforcingpoint (default false)'))
+        s += '{}\n'.format(class_utils._field_display(self,'ismappingusingneighbors','set to true if forcing when ismappedforcing is true, forcing should be interpolated instead of using mappedforcingpoint value (default false). With this method, the forcing to be remapped onto the model mesh should be on a regular (equal degree interval for lat/lon OR equal length interval for x/y) grid, so that the 4 forcing neighbors form a rectangle. NOTE: if using this option with ismappingneighborxy as false, make sure that the model mesh uses the default Polar projections of Northern Hemisphere EPSG:3413 and Southern Hemisphere EPSG:3031.'))
+        s += '{}\n'.format(class_utils._field_display(self,'ismappingneighborxy','set to true if ismappingusingneighbors is true, and the forcing regular grid is x,y instead of lat,lon (default false)'))
         s += '{}\n'.format(class_utils._field_display(self,'isprecipforcingremapped','set to true if ismappedforcing is true and precip should be downscaled from native grid (Default value is true)'))
         s += '{}\n'.format(class_utils._field_display(self,'iscompressedforcing','set to true to compress the input matrices when writing to binary (default false)'))
         s += '{}\n'.format(class_utils._field_display(self, 'Ta', '2 m air temperature, in Kelvin'))
@@ -1485,16 +1495,23 @@ class gemb(class_registry.manage_state):
         s += '{}\n'.format(class_utils._field_display(self, 'dulwrfValue', 'Specified bias to be applied to the outward long wave radiation at every element (W/m-2, +upward)'))
         s += '{}\n'.format(class_utils._field_display(self, 'teValue', 'Outward longwave radiation thermal emissivity forcing at every element (default in code is 1)'))
         s += '{}\n'.format(class_utils._field_display(self, 'teThresh', ['Apply eIdx method to all areas with effective grain radius above this value (mm),', 'or else apply direct input value from teValue, allowing emissivity to be altered.']))
+        s += '{}\n'.format(class_utils._field_display(self, 'teDefault', ['Default value for thermal emissivity.']))
         s += '{}\n'.format(class_utils._field_display(self, 'eIdx', ['method for calculating emissivity (default is 1)',
             '0: direct input from teValue parameter, no use of teThresh',
-            '1: default value of 1, in areas with grain radius below teThresh',
-            '2: default value of 1, in areas with grain radius below teThresh and areas of dry snow (not bare ice or wet) at the surface']))
+            '1: default value of teDefault, in areas with grain radius below teThresh',
+            '2: default value of teDefault, in areas with grain radius below teThresh and areas of dry snow (not bare ice or wet) at the surface',
+            '3: default value of teDefault, in areas with grain radius below teThresh and areas of dry snow (no melt) at the surface']))
         s += '{}\n'.format(class_utils._field_display(self, 'tcIdx', ['method for calculating thermal conductivity (default is 1)',
             '1: after Sturm et al, 1997',
             '2: after Calonne et al., 2011']))
 
         s += '{}\n'.format(class_utils._field_display(self,'mappedforcingpoint','Mapping of which forcing point will map to each mesh element for ismappedforcing option (integer). Size number of elements.'))
+        s += '{}\n'.format(class_utils._field_display(self,'mappedforcingneighbors','Which forcing points should be used, along with mappedforcing point, to interpolate forcing between points, onto the element grid. Should be the the next three nearest points after mappedforcingpoint, which together surround the element in question. Used with the ismappedforcing and the ismappingusingneighbors options set true (integer). Set all columns to 0 to use nearest neighbor for that element. Size number of elements x 3.'))
         s += '{}\n'.format(class_utils._field_display(self,'mappedforcingelevation','The elevation of each mapped forcing location (m above sea level) for ismappedforcing option. Size number of forcing points.'))
+        s += '{}\n'.format(class_utils._field_display(self,'lat_mappedforcing','The latitude coordinate of each mapped forcing location (degrees N) for ismappedforcing and ismappingusingneighbors options, if ismappingneighborxy=false. Size number of forcing points. NOTE that currently the GEMB mapping option (ismappedforcing with ismappingusingneighbors is true and ismappingneighborxy is false) assumes that the model mesh uses the default Polar projections of Northern Hemisphere EPSG:3413 or Southern Hemisphere EPSG:3031.'))
+        s += '{}\n'.format(class_utils._field_display(self,'lon_mappedforcing','The longitude coordinate of each mapped forcing location (degrees E) for ismappedforcing and ismappingusingneighbors options, if ismappingneighborxy=false. Size number of forcing points. NOTE that currently the GEMB mapping option (ismappedforcing with ismappingusingneighbors is true and ismappingneighborxy is false) assumes that the model mesh uses the default Polar projections of Northern Hemisphere EPSG:3413 or Southern Hemisphere EPSG:3031.'))
+        s += '{}\n'.format(class_utils._field_display(self,'x_mappedforcing','The x coordinate of each mapped forcing location (m in the same projection as the model mesh) for ismappedforcing and ismappingusingneighbors options, if ismappingneighborxy=true. Size number of forcing points.'))
+        s += '{}\n'.format(class_utils._field_display(self,'y_mappedforcing','The y coordinate of each mapped forcing location (m in the same projection as the model mesh) for ismappedforcing and ismappingusingneighbors options, if ismappingneighborxy=true. Size number of forcing points.'))
         s += '{}\n'.format(class_utils._field_display(self,'mappedforcingprecipscaling','PMap of a precipitation multiplier correction term to be applied to forcing P when ismappedforcing and isprecipforcingremapped options are true. Size number of elements. (Default is 1)'))
         s += '{}\n'.format(class_utils._field_display(self,'lapseTaValue','Temperature lapse rate of each mapped forcing location, if forcing has different grid and should be remapped for ismappedforcing option. (Default value is -0.006 K m-1., vector of mapping points)'))
         s += '{}\n'.format(class_utils._field_display(self,'lapsedlwrfValue','Longwave down lapse rate of each mapped forcing location, if forcing has different grid and should be remapped for ismappedforcing option. (Default value is -0.032 W m-2 m-1., vector of mapping points)'))
@@ -1648,8 +1665,7 @@ class gemb(class_registry.manage_state):
         class_utils._check_field(md, fieldname = 'smb.isdeltaLWup', values = [0, 1])
         class_utils._check_field(md, fieldname = 'smb.isconstrainsurfaceT', values = [0, 1])
         class_utils._check_field(md, fieldname = 'smb.ismappedforcing', values = [0, 1])
-        class_utils._check_field(md, fieldname = 'smb.isprecipforcingremapped', values = [0, 1])
-        class_utils._check_field(md, fieldname = 'smb.iscompressedforcing', values = [0, 1])
+        class_utils._check_field(md, fieldname = 'smb.ismappingusingneighbors', values = [0, 1])
 
         sizeta=np.shape(self.Ta)
         class_utils._check_field(md, fieldname = 'smb.Ta', mappedtimeseries = True, gt = 273-100, lt = 273+100, allow_nan = False, allow_inf = False) #-100/100 celsius min/max value
@@ -1674,17 +1690,28 @@ class gemb(class_registry.manage_state):
             class_utils._check_field(md, fieldname = 'smb.mappedforcingelevation', size = (sizeta[0]-1, ), allow_nan = False, allow_inf = False)
             if np.prod(np.shape(self.lapseTaValue)) == 1:
                 warnings.warn('pyissm.model.classes.smb.gemb: smb.lapseTaValue is now a vector of mapped elements. Set to md.smb.lapseTaValue * np.ones(np.shape(md.smb.mappedforcingelevation))')
-            if np.prod(np.shape(self.lapsedlwrfValue)) == 1:
-                warnings.warn('pyissm.model.classes.smb.gemb: smb.lapsedlwrfValue is now a vector of mapped elements. Set to md.smb.lapsedlwrfValue * np.ones(np.shape(md.smb.mappedforcingelevation))')
             class_utils._check_field(md, fieldname = 'smb.lapseTaValue', size = (sizeta[0]-1, ), allow_nan = False, allow_inf = False)
-            class_utils._check_field(md, fieldname = 'smb.lapsedlwrfValue', size = (sizeta[0]-1, ), allow_nan = False, allow_inf = False)                       
+            class_utils._check_field(md, fieldname = 'smb.lapsedlwrfValue', size = (sizeta[0]-1, ), allow_nan = False, allow_inf = False)
+
+            if self.ismappingusingneighbors:
+                class_utils._check_field(md, fieldname = 'smb.mappedforcingneighbors', size = (md.mesh.numberofelements, 3), ge = 0, allow_nan = False, allow_inf = False)
+                if self.ismappingneighborxy:
+                    class_utils._check_field(md, fieldname = 'smb.x_mappedforcing', size = (sizeta[0]-1, ), allow_nan = False, allow_inf = False)
+                    class_utils._check_field(md, fieldname = 'smb.y_mappedforcing', size = (sizeta[0]-1, ), allow_nan = False, allow_inf = False)
+                else:
+                    class_utils._check_field(md, fieldname = 'smb.lat_mappedforcing', size = (sizeta[0]-1, ), allow_nan = False, allow_inf = False)
+                    class_utils._check_field(md, fieldname = 'smb.lon_mappedforcing', size = (sizeta[0]-1, ), allow_nan = False, allow_inf = False)
+
+                if np.prod(np.shape(self.mappedforcingneighbors))==1:
+                    print("WARNING:smb.mappedforcingneighbors is now a matrix of size [number_of_elements 3]. If ismappingusingneighbors is true, this matrix mush specify the mapping points, that along with mappedforcing point, surround each element.")
+
         if self.isprecipforcingremapped:
             class_utils._check_field(md, fieldname = 'smb.mappedforcingprecipscaling', size = (md.mesh.numberofelements,), ge = 0, allow_nan = False, allow_inf = False)
             if np.prod(np.shape(self.mappedforcingprecipscaling)) == 1:
                 warnings.warn('pyissm.model.classes.smb.gemb: smb.mappedforcingprecipscaling is now a vector of mapped elements. Set to md.smb.mappedforcingprecipscaling * np.ones(np.shape(md.smb.mappedforcingpoint))')
 
         class_utils._check_field(md, fieldname = 'smb.aIdx', values = [0, 1, 2, 3, 4], allow_nan = False, allow_inf = False)
-        class_utils._check_field(md, fieldname = 'smb.eIdx', values = [0, 1, 2], allow_nan = False, allow_inf = False)
+        class_utils._check_field(md, fieldname = 'smb.eIdx', values = [0, 1, 2, 3], allow_nan = False, allow_inf = False)
         class_utils._check_field(md, fieldname = 'smb.tcIdx', values = [1, 2], allow_nan = False, allow_inf = False)
         class_utils._check_field(md, fieldname = 'smb.swIdx', values = [0, 1], allow_nan = False, allow_inf = False)
         class_utils._check_field(md, fieldname = 'smb.denIdx', values = [1, 2, 3, 4, 5, 6, 7], allow_nan = False, allow_inf = False)
@@ -1699,7 +1726,8 @@ class gemb(class_registry.manage_state):
         class_utils._check_field(md, fieldname = 'smb.ThermoDeltaTScaling', ge = 0, le = 1, allow_nan = False, allow_inf = False)
         class_utils._check_field(md, fieldname = 'smb.adThresh', ge = 0, allow_nan = False, allow_inf = False)
         class_utils._check_field(md, fieldname = 'smb.teThresh', ge = 0, allow_nan = False, allow_inf = False)
-        
+        class_utils._check_field(md, fieldname = 'smb.teDefault', ge = 0, le = 1.1, allow_nan = False, allow_inf = False)
+
         class_utils._check_field(md, fieldname = 'smb.aValue', timeseries = True, ge = 0, le = 1, allow_nan = False, allow_inf = True)
         if (self.aIdx in (1, 2) if isinstance(self.aIdx, int) 
             else list(self.aIdx) == [1, 2] if isinstance(self.aIdx, (list, np.ndarray)) 
@@ -1805,7 +1833,7 @@ class gemb(class_registry.manage_state):
         ## Write Boolean fields
         fieldnames = ['isgraingrowth', 'isalbedo', 'isshortwave', 'isthermal', 'isaccumulation',
                       'ismelt', 'isdensification', 'isturbulentflux', 'isconstrainsurfaceT',
-                      'isdeltaLWup', 'ismappedforcing', 'isprecipforcingremapped']
+                      'isdeltaLWup', 'ismappedforcing', 'ismappingusingneighbors', 'ismappingneighborxy', 'isprecipforcingremapped']
         for field in fieldnames:
             execute._write_model_field(fid, prefix, obj = self, fieldname = field, format = 'Boolean')
 
@@ -1831,7 +1859,7 @@ class gemb(class_registry.manage_state):
 
         ## Write Double fields
         fieldnames = ['InitDensityScaling', 'ThermoDeltaTScaling', 'outputFreq', 'aSnow', 'aIce',
-                      'cldFrac', 't0wet', 't0dry', 'K', 'adThresh', 'teThresh']
+                      'cldFrac', 't0wet', 't0dry', 'K', 'adThresh', 'teThresh', 'teDefault']
         for field in fieldnames:
             execute._write_model_field(fid, prefix, obj = self, fieldname = field, format = 'Double')
 
@@ -1857,6 +1885,13 @@ class gemb(class_registry.manage_state):
             execute._write_model_field(fid, prefix, obj = self, fieldname = 'mappedforcingelevation', format ='DoubleMat', mattype = 3)
             execute._write_model_field(fid, prefix, obj = self, fieldname = 'lapseTaValue', format ='DoubleMat', mattype = 3)
             execute._write_model_field(fid, prefix, obj = self, fieldname = 'lapsedlwrfValue', format ='DoubleMat', mattype = 3)
+        if self.ismappingneighborxy:
+            execute._write_model_field(fid, prefix, obj = self, fieldname = 'x_mappedforcing', format ='DoubleMat', mattype = 3)
+            execute._write_model_field(fid, prefix, obj = self, fieldname = 'y_mappedforcing', format ='DoubleMat', mattype = 3)
+        else:
+            execute._write_model_field(fid, prefix, obj = self, fieldname = 'lat_mappedforcing', format ='DoubleMat', mattype = 3)
+            execute._write_model_field(fid, prefix, obj = self, fieldname = 'lon_mappedforcing', format ='DoubleMat', mattype = 3)
+
         if self.isprecipforcingremapped:
             execute._write_model_field(fid, prefix, obj = self, fieldname = 'mappedforcingprecipscaling', format ='DoubleMat', mattype = 2)
 

--- a/src/pyissm/tools/geometry.py
+++ b/src/pyissm/tools/geometry.py
@@ -4,6 +4,7 @@ Geometry-related functions for ISSM
 This module contains functions to compute geometric properties on ISSM model meshes.
 """
 
+import warnings
 import numpy as np
 from pyissm import model
 
@@ -132,4 +133,91 @@ def nowicki_profile(x):
     b[mid:] = sea - h[mid:] / (1 + delta)
 
     return b, h, sea
+
+
+def effectivepressure(md, head=None):
+    """
+    Calculate the effective basal pressure N from md.geometry and the
+    effective pressure coupling rule in md.friction.
+
+    Parameters
+    ----------
+    md : object
+        ISSM model object.
+    head : array-like, optional
+        Hydraulic head at mesh vertices (m). Only used when
+        ``md.friction.coupling == 4``.
+
+    Returns
+    -------
+    N : ndarray
+        Effective pressure at the base (Pa).
+
+    Raises
+    ------
+    ValueError
+        If ``coupling == 4`` and ``md.hydrology`` is not a
+        ``hydrologyprescribe`` instance and no ``head`` is provided.
+    ValueError
+        If an unsupported coupling value is given.
+
+    Notes
+    -----
+    Coupling modes:
+
+    * 0 — Uniform sheet; negative water pressure permitted (default).
+    * 1 — Effective pressure equals overburden pressure.
+    * 2 — Uniform sheet; water pressure clamped to >= 0.
+    * 3 — Prescribed effective pressure from ``md.friction.effective_pressure``.
+    * 4 — Dynamically coupled to the hydrology model (``md.hydrology.head``
+          or a supplied ``head`` array).
+
+    See also
+    --------
+    basalstress
+    """
+    from pyissm.model.classes.hydrology import shreve as hydrologyprescribe  # closest prescribe analogue
+
+    if hasattr(md.friction, 'coupling'):
+        coupling = md.friction.coupling
+    else:
+        warnings.warn('md.friction.coupling not found; defaulting to coupling=0.')
+        coupling = 0
+
+    sealevel = 0.0  # sea level reference elevation (m)
+
+    p_ice   = md.constants.g * md.materials.rho_ice   * md.geometry.thickness
+    p_water = md.constants.g * md.materials.rho_water * (sealevel - md.geometry.base)
+
+    if coupling == 0:
+        N = p_ice - p_water
+    elif coupling == 1:
+        N = p_ice
+    elif coupling == 2:
+        p_water = np.maximum(p_water, 0.0)
+        N = p_ice - p_water
+    elif coupling == 3:
+        N = np.maximum(md.friction.effective_pressure, 0.0)
+    elif coupling == 4:
+        if head is not None:
+            head = np.asarray(head)
+            if head.size != md.mesh.numberofvertices:
+                raise ValueError(
+                    f'head size ({head.size}) does not match numberofvertices '
+                    f'({md.mesh.numberofvertices}).'
+                )
+            p_water = md.constants.g * md.materials.rho_freshwater * (head - md.geometry.base)
+        else:
+            if hasattr(md.hydrology, 'head'):
+                p_water = md.constants.g * md.materials.rho_freshwater * (md.hydrology.head - md.geometry.base)
+            else:
+                raise ValueError(
+                    f'coupling=4 is not supported for {type(md.hydrology).__name__}. '
+                    'Provide a head array or use a hydrology class with a head field.'
+                )
+        N = p_ice - p_water
+    else:
+        raise ValueError(f'Unsupported coupling value: {coupling}')
+
+    return N
 

--- a/test/ci_tests/test258.py
+++ b/test/ci_tests/test258.py
@@ -2,6 +2,7 @@
 import numpy as np
 from scipy.interpolate import NearestNDInterpolator
 import sys
+from xy2ll import *
 import pyissm
 
 # Parameterise model
@@ -20,6 +21,8 @@ md2 = pyissm.model.param.parameterize(md2, '../assets/Par/SquareShelf.py')
 md.smb = pyissm.model.classes.smb.gemb(md.mesh)
 md.smb.dsnowIdx = 1
 md.smb.swIdx = 1
+md.smb.teThresh = 2
+md.smb.teValue[:] = .95
 
 # load hourly surface forcing date from 1979 to 2009:
 if sys.version_info.major == 2:
@@ -45,6 +48,7 @@ xe=np.mean(md.mesh.x[md.mesh.elements-1],axis=1)
 ye=np.mean(md.mesh.y[md.mesh.elements-1],axis=1)
 xe2=np.mean(md2.mesh.x[md2.mesh.elements-1],axis=1)
 ye2=np.mean(md2.mesh.y[md2.mesh.elements-1],axis=1)
+[md.smb.lat_mappedforcing, md.smb.lon_mappedforcing]=xy2ll(xe2,ye2,+1)
 
 mpoints=np.arange(1,md2.mesh.numberofelements+1)
 

--- a/test/ci_tests/test258.py
+++ b/test/ci_tests/test258.py
@@ -2,7 +2,6 @@
 import numpy as np
 from scipy.interpolate import NearestNDInterpolator
 import sys
-from xy2ll import *
 import pyissm
 
 # Parameterise model
@@ -48,7 +47,7 @@ xe=np.mean(md.mesh.x[md.mesh.elements-1],axis=1)
 ye=np.mean(md.mesh.y[md.mesh.elements-1],axis=1)
 xe2=np.mean(md2.mesh.x[md2.mesh.elements-1],axis=1)
 ye2=np.mean(md2.mesh.y[md2.mesh.elements-1],axis=1)
-[md.smb.lat_mappedforcing, md.smb.lon_mappedforcing]=xy2ll(xe2,ye2,+1)
+[md.smb.lat_mappedforcing, md.smb.lon_mappedforcing]=pyissm.tools.general.xy_to_ll(xe2,ye2,+1)
 
 mpoints=np.arange(1,md2.mesh.numberofelements+1)
 

--- a/test/ci_tests/test259.py
+++ b/test/ci_tests/test259.py
@@ -2,6 +2,7 @@
 import numpy as np
 from scipy.interpolate import NearestNDInterpolator
 import sys
+from xy2ll import *
 import pyissm
 
 # Parameterise model
@@ -20,6 +21,10 @@ md2 = pyissm.model.param.parameterize(md2, '../assets/Par/SquareShelf.py')
 md.smb = pyissm.model.classes.smb.gemb(md.mesh)
 md.smb.dsnowIdx = 1
 md.smb.swIdx = 1
+md.smb.aIdx = 0
+md.smb.eIdx = 3
+md.smb.teValue[:] = 0.95
+md.smb.teDefault = 0.97
 
 # load hourly surface forcing date from 1979 to 2009:
 if sys.version_info.major == 2:
@@ -45,6 +50,7 @@ xe=np.mean(md.mesh.x[md.mesh.elements-1],axis=1)
 ye=np.mean(md.mesh.y[md.mesh.elements-1],axis=1)
 xe2=np.mean(md2.mesh.x[md2.mesh.elements-1],axis=1)
 ye2=np.mean(md2.mesh.y[md2.mesh.elements-1],axis=1)
+[md.smb.lat_mappedforcing, md.smb.lon_mappedforcing]=xy2ll(xe2,ye2,+1)
 
 mpoints=np.arange(1,md2.mesh.numberofelements+1)
 

--- a/test/ci_tests/test259.py
+++ b/test/ci_tests/test259.py
@@ -2,7 +2,6 @@
 import numpy as np
 from scipy.interpolate import NearestNDInterpolator
 import sys
-from xy2ll import *
 import pyissm
 
 # Parameterise model
@@ -50,7 +49,7 @@ xe=np.mean(md.mesh.x[md.mesh.elements-1],axis=1)
 ye=np.mean(md.mesh.y[md.mesh.elements-1],axis=1)
 xe2=np.mean(md2.mesh.x[md2.mesh.elements-1],axis=1)
 ye2=np.mean(md2.mesh.y[md2.mesh.elements-1],axis=1)
-[md.smb.lat_mappedforcing, md.smb.lon_mappedforcing]=xy2ll(xe2,ye2,+1)
+[md.smb.lat_mappedforcing, md.smb.lon_mappedforcing]=pyissm.tools.general.xy_to_ll(xe2,ye2,+1)
 
 mpoints=np.arange(1,md2.mesh.numberofelements+1)
 


### PR DESCRIPTION
## Summary

Update pyISSM for the 2026.05.08 ISSM release.

This PR:
- updates CI/build workflows for the new ISSM external package setup
- removes the runtime M1QN3 availability check from `inversion.py`
- updates GEMB SMB test setup for new SMB input fields
- adds `pyissm.tools.geometry.effectivepressure()` to compute basal effective pressure from model geometry/friction coupling

## Changes

- Removed `semic` installation from standard/benchmark ISSM CI builds.
- Added/kept required AD build dependencies including `gsl`, `codipack`, and `medipack`.
- Updated `test258.py` and `test259.py` for new SMB data input requirements.
- Added effective pressure calculation support for friction coupling modes `0–4`.

## Testing

- CI/CD build triggered.
- Updated affected CI tests for the new SMB interface.