### PR TITLE
fix(execute): return immediately from wait_on_lock in interactive mode

### DIFF
--- a/src/pyissm/model/execute.py
+++ b/src/pyissm/model/execute.py
@@ -1368,6 +1368,12 @@ def wait_on_lock(md):
     # Determine whether the cluster is the local machine
     is_local = (md.cluster.name.lower() == tools.config.get_hostname().lower())
 
+    # In interactive mode the queue script runs synchronously (no '&' at end of
+    # the mpiexec command), so launch_queue_job already blocked until the job
+    # finished before we get here.  There is nothing left to wait for.
+    if getattr(md.cluster, 'interactive', False):
+        return True
+
     elapsed = 0
     last_print = -60  # ensures a message is printed on the first verbose tick
 


### PR DESCRIPTION
In interactive mode (md.cluster.interactive = 1), the queue script runs mpiexec without a trailing '&', so launch_queue_job blocks via subprocess.call() until ISSM exits. By the time wait_on_lock is called, the job has already completed — there is nothing to poll for.

ISSM's original waitonlock.py handles this with an early return guarded by isa(cluster, generic), but that check always fails in pyISSM because md.cluster is pyissm.model.classes.cluster.generic, a different class from ISSM's src/m/classes/clusters/generic.py. The reimplemented wait_on_lock in execute.py was missing this short-circuit entirely.

The missing early return caused tests to hang for the full timeout (~2^31 minutes by default) whenever ISSM crashed in interactive mode, because a crashed job never writes a .lock file.

Fix by returning True immediately when md.cluster.interactive is set.